### PR TITLE
Add support for single-field record types

### DIFF
--- a/src/Elm/Export/Persist/Ent.hs
+++ b/src/Elm/Export/Persist/Ent.hs
@@ -65,6 +65,9 @@ instance (KnownSymbol field, ElmType a) => ElmType (Ent field a) where
       ElmDatatype name (RecordConstructor x (Values v vals)) ->
         ElmDatatype name (RecordConstructor x
                             (Values v (addIdToVals keyname vals)))
+      ElmDatatype name (RecordConstructor x f@(ElmField _ _)) ->
+        ElmDatatype name (RecordConstructor x
+                            (Values f $ elmIdField (T.pack keyname)))
       x -> x
     where
       keyname :: String


### PR DESCRIPTION
Test case:
```haskell
share [mkPersist sqlSettings, mkMigrate "migrateAccount"] [persistLowerCase|
Account
  email Text
  deriving Show Generic
|]
```

Before, note the lack of an `id` field:
```elm
type alias Account =
    { email : String
    }
```

After:
```elm
type alias Account =
    { email : String
    , id : Int
    }
```